### PR TITLE
Convert Region to type literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Sauce Labs SDK for the Test-Composer API.
 const {Region, TestComposer} = require('@saucelabs/testcomposer');
 
 const client = new TestComposer({
-  region: Region.USWest1,
+  region: 'us-west-1',
   username: process.env.SAUCE_USERNAME,
   accessKey: process.env.SAUCE_ACCESS_KEY,
   headers: {'User-Agent': `your-fancy-reporter/1.2.3`}
@@ -37,7 +37,7 @@ console.log(job.url); // the full URL of the job
 const Readable = require('stream').Readable;
 
 const client = new TestComposer({
-  region: Region.USWest1,
+  region: 'us-west-1',
   username: process.env.SAUCE_USERNAME,
   accessKey: process.env.SAUCE_ACCESS_KEY,
   headers: {'User-Agent': `your-fancy-reporter/1.2.3`}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,23 +3,19 @@ import FormData from "form-data";
 import * as stream from "stream";
 
 // The Sauce Labs region.
-export enum Region {
-  USWest1 = 'us-west-1',
-  EUCentral1 = 'eu-central-1',
-  Staging = 'staging'
-}
+export type Region = 'us-west-1' | 'eu-central-1' | 'staging';
 
 const apiURLMap = new Map<Region, string>([
-    [Region.USWest1, 'https://api.us-west-1.saucelabs.com/v1/testcomposer'],
-    [Region.EUCentral1, 'https://api.eu-central-1.saucelabs.com/v1/testcomposer'],
-    [Region.Staging, 'https://api.staging.saucelabs.net/v1/testcomposer']
+    ['us-west-1', 'https://api.us-west-1.saucelabs.com/v1/testcomposer'],
+    ['eu-central-1', 'https://api.eu-central-1.saucelabs.com/v1/testcomposer'],
+    ['staging', 'https://api.staging.saucelabs.net/v1/testcomposer']
   ]
 );
 
 const appURLMap = new Map<Region, string>([
-    [Region.USWest1, 'https://app.saucelabs.com'],
-    [Region.EUCentral1, 'https://app.eu-central-1.saucelabs.com'],
-    [Region.Staging, 'https://app.staging.saucelabs.net']
+    ['us-west-1', 'https://app.saucelabs.com'],
+    ['eu-central-1', 'https://app.eu-central-1.saucelabs.com'],
+    ['staging', 'https://app.staging.saucelabs.net']
   ]
 );
 
@@ -82,7 +78,7 @@ export class TestComposer {
 
   constructor(opts: Options) {
     this.opts = opts;
-    this.url = apiURLMap.get(opts.region) || Region.USWest1;
+    this.url = apiURLMap.get(opts.region) || 'us-west-1';
     this.requestConfig = {auth: {username: this.opts.username, password: this.opts.accessKey}, headers: opts.headers};
   }
 

--- a/tests/integration/e2e.spec.js
+++ b/tests/integration/e2e.spec.js
@@ -9,7 +9,7 @@ beforeAll(() => {
   expect(process.env.SAUCE_ACCESS_KEY).toBeDefined()
 
   client = new TestComposer({
-    region: Region.USWest1,
+    region: 'us-west-1',
     username: process.env.SAUCE_USERNAME,
     accessKey: process.env.SAUCE_ACCESS_KEY,
     headers: {'User-Agent': `node-testcomposer/0.0.0`}


### PR DESCRIPTION
Convert Region from `enum` to `type` string literal.
Having used it as an enum makes it extremely unwieldy in any practical sense, especially in any typed environment (typescript).
Use typed string literal for the best of both worlds.