### PR TITLE
feat: Use native FormData

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "axios": "^1.7.5",
-        "form-data": "^4.0.0"
+        "axios": "^1.7.5"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "typescript-eslint": "^8.3.0"
       },
       "engines": {
-        "node": ">=16.13.2"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
   },
   "homepage": "https://github.com/saucelabs/node-testcomposer#readme",
   "dependencies": {
-    "axios": "^1.7.5",
-    "form-data": "^4.0.0"
+    "axios": "^1.7.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16.13.2"
+    "node": ">=18.0.0"
   },
   "bugs": {
     "url": "https://github.com/saucelabs/node-testcomposer/issues"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosRequestConfig } from 'axios';
-import FormData from 'form-data';
 import * as stream from 'stream';
 
 // The Sauce Labs region.
@@ -115,7 +114,9 @@ export class TestComposer {
   async uploadAssets(jobId: string, assets: Asset[]) {
     const form = new FormData();
     for (const asset of assets) {
-      form.append('file', asset.data, { filename: asset.filename });
+      const data = new Response(asset.data);
+      const blob = await data.blob();
+      form.append('file', blob, asset.filename);
     }
 
     const resp = await axios.put(


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

`form-data` polyfill is no longer necessary; node has supported `FormData` since node 18. And the form-data package was causing issues downstream so switch to the natively supported version.